### PR TITLE
Steam Summer Sale 2022: Add automatic claim for final reward

### DIFF
--- a/Steam Store - Cheat Summar Sale 2022 Badge.js
+++ b/Steam Store - Cheat Summar Sale 2022 Badge.js
@@ -53,9 +53,8 @@ if (jQuery("#application_config").data("userinfo") == null) {
 			"door_index":     11, // final reward
 			"clan_accountid": 39049601, // https://store.steampowered.com/news/group/39049601
 		})
-		.done((data) => {
+		.done((json) => {
 			console.log("Response received: (2/3)");
-			const json = JSON.parse(data);
 			if (json.success == 1) {
 				console.log("Succeeded! (3/3)");
 			} else {

--- a/Steam Store - Cheat Summar Sale 2022 Badge.js
+++ b/Steam Store - Cheat Summar Sale 2022 Badge.js
@@ -1,7 +1,20 @@
 /* eslint-env browser */
 /* global g_sessionID jQuery */
 
+/* HOW TO USE:
+1. Open Console tab of your browser's DevTools
+Chrome: CTRL+SHIFT+J
+Firefox: CTRL+SHIFT+K
+
+2. Copy-paste this entire script
+3. Press ENTER and wait
+
+It should claim all 10 badges and then the final reward.
+*/
+
 /* Thanks to Sqbika#0657 for the initial script */
+/* Revadike for communication */
+/* An anonymous RadicalGDPRist for being lazy to click a single button */
 
 if (jQuery("#application_config").data("userinfo") == null) {
 	console.error("Sale settings not found. Are you on the right page?");

--- a/Steam Store - Cheat Summar Sale 2022 Badge.js
+++ b/Steam Store - Cheat Summar Sale 2022 Badge.js
@@ -3,6 +3,10 @@
 
 /* Thanks to Sqbika#0657 for the initial script */
 
+if (jQuery("#application_config").data("userinfo") == null) {
+	console.error("Sale settings not found. Are you on the right page?");
+	console.error("Go to https://store.steampowered.com/sale/clorthax_quest");
+} else {
 (async() => {
     let delay = (ms) => new Promise((res) => setTimeout(res, ms));
     await jQuery.post("/saleaction/ajaxopendoor", {
@@ -66,3 +70,4 @@
 		await delay(1500);
 	}
 })();
+}

--- a/Steam Store - Cheat Summar Sale 2022 Badge.js
+++ b/Steam Store - Cheat Summar Sale 2022 Badge.js
@@ -38,5 +38,31 @@
         } finally {
             await delay(1500);
         }
-    }
+    };
+    
+	try {
+		console.log("Claiming the final reward... (1/3)");
+		let html = await jQuery.get("/sale/clorthax_quest");
+		await jQuery.post("/saleaction/ajaxopendoor", {
+			"sessionid":      g_sessionID,
+			"authwgtoken":    jQuery("#application_config", html).data("userinfo").authwgtoken,
+			"door_index":     11, // final reward
+			"clan_accountid": 39049601, // https://store.steampowered.com/news/group/39049601
+		})
+		.done((data) => {
+			console.log("Response received: (2/3)");
+			const json = JSON.parse(data);
+			if (json.success == 1) {
+				console.log("Succeeded! (3/3)");
+			} else {
+				console.error(data);
+				console.error("Error occured. Try again or click yourself? (3/3)");
+			}
+		})
+		.fail(() => {console.error("Final reward request failed!")});
+	} catch (e) {
+		console.error("Failed to obtain final reward!", e);
+	} finally {
+		await delay(1500);
+	}
 })();


### PR DESCRIPTION
Fixes Revadike/Misc-JavaScript-Projects#1

I'm not sure if the old "You got a new badge!" message is entirely correct, because it doesn't act based on server's response. But I've got no more accounts to test :) Anyway, repeating a claim request always returns success, so in any case the user can just rerun the script.